### PR TITLE
updating set-output GHA

### DIFF
--- a/.github/workflows/reusable-docker-build.yaml
+++ b/.github/workflows/reusable-docker-build.yaml
@@ -198,4 +198,4 @@ jobs:
         id: ghcr-tag
         run: |
           echo '::echo::on'
-          echo "::set-output name=tag::gha-${{ github.run_id }}"
+          echo "tag=gha-${{ github.run_id }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
[GitHub has deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) `set-output`, so move those commands to ENV-based.

