### PR TITLE
pin GHA versions. readme and workflow tweaks

### DIFF
--- a/.github/workflows/call-local-docker-build.yaml
+++ b/.github/workflows/call-local-docker-build.yaml
@@ -4,6 +4,8 @@
 # We call the reusable workflow from its file path.
 name: Docker Build
 
+run-name: '@${{ github.actor }} builds a container image for "${{ github.event.head_commit.message }}"'
+
 on:
   push:
     branches:

--- a/.github/workflows/call-local-docker-build.yaml
+++ b/.github/workflows/call-local-docker-build.yaml
@@ -4,7 +4,9 @@
 # We call the reusable workflow from its file path.
 name: Docker Build
 
-run-name: 'Docker build by ${{ github.actor }} for "${{ github.event.workflow_run.head_commit.message }}"'
+# run-name: 'Docker build by ${{ github.actor }} for "${{ github.event.workflow_run.head_commit.message }}"'
+run-name: 'Docker build by ${{ github.actor }} for ${{ github.event.workflow_run.head_commit.message }}'
+
 
 on:
   push:
@@ -19,6 +21,18 @@ on:
       - '.github/linters/**'
 
 jobs:
+
+  testing-event-messages:
+    
+    if: always()
+
+    run: |
+      echo "event_name: ${{ github.event_name }}"
+      echo "event.workflow_run: ${{ github.event.workflow_run }}"'
+      echo "event.head_commit: ${{ github.event.head_commit }}"'
+
+    
+
   call-docker-build:
 
     name: Call Docker Build

--- a/.github/workflows/call-local-docker-build.yaml
+++ b/.github/workflows/call-local-docker-build.yaml
@@ -4,7 +4,7 @@
 # We call the reusable workflow from its file path.
 name: Docker Build
 
-run-name: '@${{ github.actor }} builds a container image for "${{ github.event.head_commit.message }}"'
+run-name: '@${{ github.actor }} builds a container image for "${{ github.event.workflow_run.head_commit.message }}"'
 
 on:
   push:

--- a/.github/workflows/call-local-docker-build.yaml
+++ b/.github/workflows/call-local-docker-build.yaml
@@ -4,12 +4,12 @@
 # We call the reusable workflow from its file path.
 name: Docker Build
 
-run-name: '@${{ github.actor }} builds a container image for "${{ github.event.workflow_run.head_commit.message }}"'
+run-name: 'Docker build by ${{ github.actor }} for "${{ github.event.workflow_run.head_commit.message }}"'
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
     paths-ignore:
       - 'README.md'
       - '.github/linters/**'

--- a/.github/workflows/call-local-docker-build.yaml
+++ b/.github/workflows/call-local-docker-build.yaml
@@ -23,15 +23,14 @@ on:
 jobs:
 
   testing-event-messages:
-    
     if: always()
-
-    run: |
-      echo "event_name: ${{ github.event_name }}"
-      echo "event.workflow_run: ${{ github.event.workflow_run }}"'
-      echo "event.head_commit: ${{ github.event.head_commit }}"'
-
-    
+    runs-on: ubuntu-latest
+    steps:
+      -
+        run: |
+          echo "event_name: ${{ github.event_name }}"
+          echo "event.workflow_run: ${{ github.event.workflow_run }}"
+          echo "event.head_commit: ${{ github.event.head_commit }}"
 
   call-docker-build:
 

--- a/.github/workflows/call-local-docker-build.yaml
+++ b/.github/workflows/call-local-docker-build.yaml
@@ -6,8 +6,8 @@ name: Docker Build
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
     paths-ignore:
       - 'README.md'
       - '.github/linters/**'

--- a/.github/workflows/call-local-docker-build.yaml
+++ b/.github/workflows/call-local-docker-build.yaml
@@ -4,10 +4,6 @@
 # We call the reusable workflow from its file path.
 name: Docker Build
 
-# run-name: 'Docker build by ${{ github.actor }} for "${{ github.event.workflow_run.head_commit.message }}"'
-run-name: 'Docker build by ${{ github.actor }} for ${{ github.event.workflow_run.head_commit.message }}'
-
-
 on:
   push:
     # branches:

--- a/.github/workflows/call-local-docker-build.yaml
+++ b/.github/workflows/call-local-docker-build.yaml
@@ -29,8 +29,9 @@ jobs:
       -
         run: |
           echo "event_name: ${{ github.event_name }}"
-          echo "event.workflow_run: ${{ github.event.workflow_run }}"
+          # echo "event.workflow_run: ${{ github.event.workflow_run }}"
           echo "event.head_commit: ${{ github.event.head_commit }}"
+          echo "event.head_commit.message: ${{ github.event.head_commit.message }}"
 
   call-docker-build:
 

--- a/.github/workflows/call-super-linter.yaml
+++ b/.github/workflows/call-super-linter.yaml
@@ -3,7 +3,7 @@
 name: Lint Code Base
 
 #run-name: '@${{ github.actor }} runs Super-Linter for "${{ github.event.head_commit.message }}"'
-run-name: 'Linting by ${{ github.actor }} for "${{ github.event.workflow_run.head_commit.message }}"'
+run-name: 'Linting by ${{ github.actor }} for ${{ github.event.workflow_run.head_commit.message }}'
 
 
 on:

--- a/.github/workflows/call-super-linter.yaml
+++ b/.github/workflows/call-super-linter.yaml
@@ -2,7 +2,7 @@
 # template source: https://github.com/bretfisher/super-linter-workflow/blob/main/templates/call-super-linter.yaml
 name: Lint Code Base
 
-run-name: '@${{ github.actor }} runs Super-Linter for "${{ github.event.head_commit.message }}"'
+run-name: '@${{ github.actor }} runs Super-Linter for "${{ github.event.workflow_run.head_commit.message }}"'
 
 on:
   

--- a/.github/workflows/call-super-linter.yaml
+++ b/.github/workflows/call-super-linter.yaml
@@ -2,6 +2,8 @@
 # template source: https://github.com/bretfisher/super-linter-workflow/blob/main/templates/call-super-linter.yaml
 name: Lint Code Base
 
+run-name: '@${{ github.actor }} runs Super-Linter for "${{ github.event.head_commit.message }}"'
+
 on:
   
   push:
@@ -22,7 +24,7 @@ jobs:
     ### https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
     ### you can also call workflows from inside the same repo via file path
 
-    #FIXME: customize uri to point to your own linter repository
+    #FIXME: customize uri to point to your own reusable linter repository
     uses: bretfisher/super-linter-workflow/.github/workflows/reusable-super-linter.yaml@main
     
     ### Optional settings examples

--- a/.github/workflows/call-super-linter.yaml
+++ b/.github/workflows/call-super-linter.yaml
@@ -2,7 +2,9 @@
 # template source: https://github.com/bretfisher/super-linter-workflow/blob/main/templates/call-super-linter.yaml
 name: Lint Code Base
 
-run-name: '@${{ github.actor }} runs Super-Linter for "${{ github.event.workflow_run.head_commit.message }}"'
+#run-name: '@${{ github.actor }} runs Super-Linter for "${{ github.event.head_commit.message }}"'
+run-name: 'Linting by ${{ github.actor }} for "${{ github.event.workflow_run.head_commit.message }}"'
+
 
 on:
   

--- a/.github/workflows/call-super-linter.yaml
+++ b/.github/workflows/call-super-linter.yaml
@@ -2,10 +2,6 @@
 # template source: https://github.com/bretfisher/super-linter-workflow/blob/main/templates/call-super-linter.yaml
 name: Lint Code Base
 
-#run-name: '@${{ github.actor }} runs Super-Linter for "${{ github.event.head_commit.message }}"'
-run-name: 'Linting by ${{ github.actor }} for ${{ github.event.workflow_run.head_commit.message }}'
-
-
 on:
   
   push:

--- a/.github/workflows/call-super-linter.yaml
+++ b/.github/workflows/call-super-linter.yaml
@@ -9,7 +9,7 @@ run-name: 'Linting by ${{ github.actor }} for "${{ github.event.workflow_run.hea
 on:
   
   push:
-    branches: [main]
+   # branches: [main]
   
   pull_request:
 

--- a/.github/workflows/call-super-linter.yaml
+++ b/.github/workflows/call-super-linter.yaml
@@ -5,7 +5,7 @@ name: Lint Code Base
 on:
   
   push:
-   branches: [main]
+    branches: [main]
   
   pull_request:
 

--- a/.github/workflows/call-super-linter.yaml
+++ b/.github/workflows/call-super-linter.yaml
@@ -5,7 +5,7 @@ name: Lint Code Base
 on:
   
   push:
-   # branches: [main]
+   branches: [main]
   
   pull_request:
 

--- a/.github/workflows/reusable-docker-build.yaml
+++ b/.github/workflows/reusable-docker-build.yaml
@@ -1,8 +1,6 @@
 ---
 name: Docker Build and Push
 
-run-name: '@${{ github.actor }} builds a container image for "${{ github.event.head_commit.message }}"'
-
 on:
 
   # REUSABLE WORKFLOW with INPUTS

--- a/.github/workflows/reusable-docker-build.yaml
+++ b/.github/workflows/reusable-docker-build.yaml
@@ -1,6 +1,8 @@
 ---
 name: Docker Build and Push
 
+run-name: '@${{ github.actor }} builds a container image for "${{ github.event.head_commit.message }}"'
+
 on:
 
   # REUSABLE WORKFLOW with INPUTS
@@ -109,28 +111,28 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
       -
         # we need qemu and buildx so we can build multiple platforms later
         name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v2.1.0
       -
         # BuildKit (used with `docker buildx`) is the best way to build images
         name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.4.1
       -
         name: Login to DockerHub
         if: inputs.dockerhub-enable
-        uses: docker/login-action@v2
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.dockerhub-username }}
           password: ${{ secrets.dockerhub-token }}
       -
         name: Login to GHCR
         if: inputs.ghcr-enable
-        uses: docker/login-action@v2
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -138,7 +140,7 @@ jobs:
       -
         name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v4.3.0
         with:
           # list of Docker images to use as base name for tags
           images: ${{ inputs.image-names }}
@@ -149,7 +151,7 @@ jobs:
         # then push to one or more registries (based on image list above in docker_meta)
         name: Docker Build and Push
         id: build_image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v4.0.0
         with:
           platforms: ${{ inputs.platforms }}
           context: ${{ inputs.context }}
@@ -167,7 +169,7 @@ jobs:
         # If PR, put image tags in the PR comments
         # from https://github.com/marketplace/actions/create-or-update-comment
         name: Find comment for image tags
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v2.2.1
         if: github.event_name == 'pull_request' && inputs.comment-enable
         id: fc
         with:
@@ -177,7 +179,7 @@ jobs:
       
         # If PR, put image tags in the PR comments
       - name: Create or update comment for image tags
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v2.1.1
         if: github.event_name == 'pull_request' && inputs.comment-enable
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ A Reusable Workflow of the Docker GitHub Actions steps. Enhanced with learnings 
 3. Setup buildx for awesome and fast building via docker/setup-buildx-action
 4. Log into Docker Hub and/or GHCR
 5. Add labels and tags via docker/metadata-action
-6. Build and push image via docker/build-push-action with layer caching
+6. Build and push image via docker/build-push-action with GitHub-based layer caching
 7. Reports tags and labels in the PR comments
 
-## This repository is part of my example repos on GitHub Actions
+## This repository is part of my examples on GitHub Actions
 
-- [bretfisher/github-actions-templates](https://github.com/BretFisher/github-actions-templates) - Main repository
+- [bretfisher/github-actions-templates](https://github.com/BretFisher/github-actions-templates) - Main reusable templates repository
 - [bretfisher/super-linter-workflow](https://github.com/BretFisher/super-linter-workflow) - Reusable linter workflow
 - (you are here) [bretfisher/docker-build-workflow](https://github.com/BretFisher/docker-build-workflow)- Reusable docker build workflow
-- [bretfisher/allhands22](https://github.com/BretFisher/github-actions-templates) - Step by step example of a Docker workflow
+- [bretfisher/docker-ci-automation](https://github.com/BretFisher/docker-ci-automation) - Step by step video and example of a Docker CI workflow
 - [My full list of container examples and tools](https://github.com/bretfisher)
 
 ## More reading
@@ -41,6 +41,7 @@ A Reusable Workflow of the Docker GitHub Actions steps. Enhanced with learnings 
 
 ## 🎉🎉🎉 Join my container DevOps community 🎉🎉🎉
 
-- [My "Vital DevOps" Discord server](https://devops.fan)
-- [My weekly YouTube Live show](https://bret.live)
+- [My Cloud Native DevOps Discord server](https://devops.fan)
+- [My weekly YouTube Live show](https://www.youtube.com/@BretFisher)
+- [My weekly newsletter](https://www.bretfisher.com/newsletter)
 - [My courses and coupons](https://www.bretfisher.com/courses)


### PR DESCRIPTION
For an example of how to pin to patch versions of Actions.

I've also noticed that the latest Dependabot will now only give you a PR if there's a new version based on your version format.

Previously: Would PR you any new version of an Action.

Now: If you are pinning to v2, it will only update on v3 release. If pinning to v2.2.1, it will PR on v2.2.2